### PR TITLE
Some small fixes

### DIFF
--- a/sms-sender.py
+++ b/sms-sender.py
@@ -22,8 +22,7 @@ def send_sms():
     if dryrun_var.get():
         payload['dryrun'] = 'yes'
 
-    # Build the URL with selected options
-    url = f"https://api.46elks.com/a1/sms"
+    url = "https://api.46elks.com/a1/sms"
 
     response = requests.post(url, data=payload, auth=(username, password))
 

--- a/sms-sender.py
+++ b/sms-sender.py
@@ -11,22 +11,21 @@ def send_sms():
     phone_number = phone_entry.get()
     sender_name = sender_entry.get()
 
-    # Encode the credentials in base64
-    credentials = base64.b64encode(f'{username}:{password}'.encode('utf-8')).decode('utf-8')
-
-    # Build the URL with selected options
-    url = f"https://api.46elks.com/a1/sms/POST?to={phone_number}&from={sender_name}&message={message}"
-    if flashsms_var.get() == 1:
-        url += "&flashsms=yes"
-    if dryrun_var.get() == 1:
-        url += "&dryrun=yes"
-
-    payload = {}
-    headers = {
-        'Authorization': f'Basic {credentials}'
+    payload = {
+            'to': phone_number,
+            'from': sender_name,
+            'message': message,
     }
 
-    response = requests.request("POST", url, headers=headers, data=payload)
+    if flashsms_var.get():
+        payload['flashsms'] = 'yes'
+    if dryrun_var.get():
+        payload['dryrun'] = 'yes'
+
+    # Build the URL with selected options
+    url = f"https://api.46elks.com/a1/sms"
+
+    response = requests.post(url, data=payload, auth=(username, password))
 
     result_label.config(text=response.text)
 


### PR DESCRIPTION
Send the parameters as actual post parameters, and use the requests library built in way of handling authorization (no need to build the headers from scratch)

The /a1/SMS/POST endpoint exists for when the client side is not able to make a post request, and needs to URL-encode the parameters instead. If possible it is better to make a POST request directly to /a1/sms with urlencoded parameters.